### PR TITLE
update @import to @use

### DIFF
--- a/material-symbols/_core.scss
+++ b/material-symbols/_core.scss
@@ -1,12 +1,13 @@
+@use "sass:string";
 $material-symbols-font-path: './' !default;
 
 // @see https://github.com/twbs/bootstrap/blob/main/scss/_functions.scss
 @function material-symbols-str-replace($string, $search, $replace: '') {
-  $index: str-index($string, $search);
+  $index: string.index($string, $search);
   @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace +
+    @return string.slice($string, 1, $index - 1) + $replace +
       material-symbols-str-replace(
-        str-slice($string, $index + str-length($search)),
+        string.slice($string, $index + string.length($search)),
         $search,
         $replace
       );
@@ -15,7 +16,7 @@ $material-symbols-font-path: './' !default;
 }
 
 @mixin material-symbols-font($font-family) {
-  $class-name: to-lower-case($font-family);
+  $class-name: string.to-lower-case($font-family);
   $class-name: material-symbols-str-replace($class-name, ' ', '-');
   $font-file: $material-symbols-font-path + $class-name;
 

--- a/material-symbols/index.scss
+++ b/material-symbols/index.scss
@@ -1,3 +1,3 @@
-@import 'outlined';
-@import 'rounded';
-@import 'sharp';
+@use 'outlined';
+@use 'rounded';
+@use 'sharp';

--- a/material-symbols/outlined.scss
+++ b/material-symbols/outlined.scss
@@ -1,3 +1,3 @@
-@import 'core';
+@use 'core';
 
 @include material-symbols-font('Material Symbols Outlined');

--- a/material-symbols/rounded.scss
+++ b/material-symbols/rounded.scss
@@ -1,3 +1,3 @@
-@import 'core';
+@use 'core';
 
 @include material-symbols-font('Material Symbols Rounded');

--- a/material-symbols/sharp.scss
+++ b/material-symbols/sharp.scss
@@ -1,3 +1,3 @@
-@import 'core';
+@use 'core';
 
 @include material-symbols-font('Material Symbols Sharp');


### PR DESCRIPTION
The usage of `@import` has been deprecated.
Global built in functions are also deprecated. 

This PR imports sass:string and uses string.to-lower-case instead and changes all `@import` rules to `@use` instead.

Angular 19 will throw warnings during compilation - this fixes this issue.

Closes #44 